### PR TITLE
RST-8311 Add IPv4 to Connection.msg

### DIFF
--- a/wireless_msgs/msg/Connection.msg
+++ b/wireless_msgs/msg/Connection.msg
@@ -19,3 +19,5 @@ int16 noise_level  # dBm
 string essid
 string bssid
 float64 frequency
+
+string ipv4 # dot notation ipv4 for this connection. For robots this is typically the wlan0 IP address.

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -149,7 +149,7 @@ def main():
             else:
                 rospy.logwarn("Robot was not associated with an AP! iwconfig output was:\n{}".format(wifi_str))
                 raise RuntimeError()
-        
+
             connection_msg.ipv4 = ipv4
             connection_msg.header.stamp = rospy.get_rostime()
             connection_msg.header.frame_id = robot

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -127,6 +127,13 @@ def main():
         except subprocess.CalledProcessError:
             connected_pub.publish(False)
 
+        # Get the ipv4 from the multiline ip_str. It might not exist at all.
+        try:
+            # eg. `inet 192.168.0.1/24`
+            ipv4 = re.search(r'inet (\d+\.\d+\.\d+\.\.\d+)\/', ip_str, re.MULTILINE).group(1)
+        except (IndexError, AttributeError):
+            ipv4 = ""
+
         try:
             wifi_str = subprocess.check_output(['iwconfig', dev], stderr=subprocess.STDOUT).decode()
             fields_str = re.split('\s\s+', wifi_str)
@@ -141,7 +148,8 @@ def main():
             else:
                 rospy.logwarn("Robot was not associated with an AP! iwconfig output was:\n{}".format(wifi_str))
                 raise RuntimeError()
-
+        
+            connection_msg.ipv4 = ipv4
             connection_msg.header.stamp = rospy.get_rostime()
             connection_msg.header.frame_id = robot
             connection_msg.wifi_chip = chip

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -130,8 +130,9 @@ def main():
         # Get the ipv4 from the multiline ip_str. It might not exist at all.
         try:
             # eg. `inet 192.168.0.1/24`
-            ipv4 = re.search(r'inet (\d+\.\d+\.\d+\.\.\d+)\/', ip_str, re.MULTILINE).group(1)
-        except (IndexError, AttributeError):
+            ipv4 = re.search(r'inet (\d+\.\d+\.\d+\.\d+)\/', ip_str, re.MULTILINE).group(1)
+        # AttributeError: search failed. Robot might not have an IP address yet.
+        except AttributeError:
             ipv4 = ""
 
         try:


### PR DESCRIPTION
Based on Tom's idea I added a `string` to `Connection.msg`.  Some might argue for an `array of uint8` but I'm not sure "type correctness" yields us much other than a weirder `rostopic echo` to debug and an array of integers to convert back into a dot notation string.  If anyone feels strongly about this I'm happy to switch it.

My implementation was reasoned about this way:

- Keep my new lookup block outside the big `try/except Exception` as that catches everything and might swallow bugs.
- Look up the IP from the existing ip_str. If not found, a blank string is the null value.