### PR TITLE
Fix bug when no ip available and use bytes

### DIFF
--- a/wireless_msgs/msg/Connection.msg
+++ b/wireless_msgs/msg/Connection.msg
@@ -20,4 +20,4 @@ string essid
 string bssid
 float64 frequency
 
-string ipv4 # dot notation ipv4 for this connection. For robots this is typically the wlan0 IP address.
+uint8[] ipv4

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -59,7 +59,7 @@ class Connection(wireless_msgs.msg.Connection):
             args['link_quality_raw'] = fields['Link Quality']
             num, den = re.split('/', args['link_quality_raw'])
             args['link_quality'] = float(num) / float(den)
-        except:
+        except Exception:
             pass
 
         super(Connection, self).__init__(**args)
@@ -126,7 +126,7 @@ def main():
             ipv4_str = re.search(r'inet (\d+\.\d+\.\d+\.\d+)\/', ip_str, re.MULTILINE).group(1)
             ipv4 = bytes([int(i) for i in ipv4_str.split('.')])
             connected_pub.publish(True)
-        except (subprocess.CalledProcessError, AttributeError) as e:
+        except (subprocess.CalledProcessError, AttributeError):
             ipv4 = bytes()
             connected_pub.publish(False)
 

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -126,13 +126,13 @@ def main():
             ipv4_str = re.search(r'inet (\d+\.\d+\.\d+\.\d+)\/', ip_str, re.MULTILINE).group(1)
             ipv4 = bytes([int(i) for i in ipv4_str.split('.')])
             connected_pub.publish(True)
-        except (subprocess.CalledProcessError, AttributeError):
+        except (subprocess.CalledProcessError, AttributeError) as e:
             ipv4 = bytes()
             connected_pub.publish(False)
 
         try:
             wifi_str = subprocess.check_output(['iwconfig', dev], stderr=subprocess.STDOUT).decode()
-            fields_str = re.split('\s\s+', wifi_str)
+            fields_str = re.split(r'\s\s+', wifi_str)
             fields_list = [re.split('[:=]', field_str, maxsplit=1) for field_str in fields_str]
             fields_dict = {'dev': fields_str[0], 'type': fields_str[1]}
             fields_dict.update(dict([field for field in fields_list if len(field) == 2]))

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -122,7 +122,7 @@ def main():
     while not rospy.is_shutdown():
         try:
             ip_str = subprocess.check_output(['ip', 'addr', 'show', dev], stderr=subprocess.STDOUT).decode()
-            # eg. `inet 192.168.0.1/24`
+            # eg. `inet 192.168.0.1/24`. Will raise AttributeError if not found.
             ipv4_str = re.search(r'inet (\d+\.\d+\.\d+\.\d+)\/', ip_str, re.MULTILINE).group(1)
             ipv4 = bytes([int(i) for i in ipv4_str.split('.')])
             connected_pub.publish(True)

--- a/wireless_watcher/scripts/watcher_node
+++ b/wireless_watcher/scripts/watcher_node
@@ -122,18 +122,13 @@ def main():
     while not rospy.is_shutdown():
         try:
             ip_str = subprocess.check_output(['ip', 'addr', 'show', dev], stderr=subprocess.STDOUT).decode()
-            if re.search(r'^\s*inet\s', ip_str, re.MULTILINE):
-                connected_pub.publish(True)
-        except subprocess.CalledProcessError:
-            connected_pub.publish(False)
-
-        # Get the ipv4 from the multiline ip_str. It might not exist at all.
-        try:
             # eg. `inet 192.168.0.1/24`
-            ipv4 = re.search(r'inet (\d+\.\d+\.\d+\.\d+)\/', ip_str, re.MULTILINE).group(1)
-        # AttributeError: search failed. Robot might not have an IP address yet.
-        except AttributeError:
-            ipv4 = ""
+            ipv4_str = re.search(r'inet (\d+\.\d+\.\d+\.\d+)\/', ip_str, re.MULTILINE).group(1)
+            ipv4 = bytes([int(i) for i in ipv4_str.split('.')])
+            connected_pub.publish(True)
+        except (subprocess.CalledProcessError, AttributeError):
+            ipv4 = bytes()
+            connected_pub.publish(False)
 
         try:
             wifi_str = subprocess.check_output(['iwconfig', dev], stderr=subprocess.STDOUT).decode()

--- a/wireless_watcher/setup.cfg
+++ b/wireless_watcher/setup.cfg
@@ -1,5 +1,2 @@
-[pep8]
-max-line-length = 120
- 
-[flake8]
+[pycodestyle]
 max-line-length = 120


### PR DESCRIPTION
Fixes #8 if there is no wireless interface available.

It also changes from `string` to `uint8[]` for bandwidth purposes (goes from 186 Bytes to 177 Bytes per message). 

The output from `rostopic echo` is still understandable IMO `ipv4: [192, 168, 1, 186]`